### PR TITLE
 node is undefined error at graph.component.ts #105 

### DIFF
--- a/src/app/tool/main-panel/graph.component.ts
+++ b/src/app/tool/main-panel/graph.component.ts
@@ -290,7 +290,11 @@ export class GraphComponent {
         const x = this.getOriginalXPosition(mouse[0] * this.dpr);
         const y = this.getOriginalYPosition(mouse[1] * this.dpr);
         const node = this.simulation.find( x, y);
-        return this.simulation.find( x, y, node.r + (node.r / 7));
+        if (node) {
+            return this.simulation.find( x, y, node.r + (node.r / 7));
+        } else {
+            return undefined;
+        }
     }
 
     setSimulation(): Promise<d3.forceSimulation> {

--- a/src/app/tool/multi-use/tweet.component.ts
+++ b/src/app/tool/multi-use/tweet.component.ts
@@ -15,10 +15,13 @@ export class TweetComponent implements OnChanges {
     @Input('cards')
     cards = true;
 
+    lastTweetId;
+
     @ViewChild('tweetElement') tweetElement: ElementRef;
 
     ngOnChanges() {
-        if ( this.tweetId) {
+        if ( this.tweetId && this.tweetId !== this.lastTweetId) {
+            this.lastTweetId = this.tweetId;
             window['twttr'].ready( twttr => {
                 const domTweet = this.tweetElement.nativeElement;
                 // Remove old tweet if present
@@ -37,6 +40,8 @@ export class TweetComponent implements OnChanges {
                     ).then(() => {
                         // Callback to parent for timeline loading animation
                         this.rendered.emit(this.tweetId);
+                    }).catch( () => {
+                        console.log('createTweet() Promise has been rejected by reload.');
                     });
                 } else {
                     // Create tweet from tweetId
@@ -51,6 +56,8 @@ export class TweetComponent implements OnChanges {
                     ).then(() => {
                         // Callback to parent for timeline loading animation
                         this.rendered.next(this.tweetId);
+                    }).catch( () => {
+                        console.log('createTweet() Promise has been rejected by reload.');
                     });
                 }
             });


### PR DESCRIPTION
Resolves #105

# Bug Description
The errors appeared because while a new tracemap loads, the simulation of the old tracemap is still loaded. I just delete the old tracemaps nodes and edges for it to disappear and the simulation is nevertheless updated somewhen in the process of loading the new tracemap.
If you now hover the canvas during loading of the new tracemap, the `getHoveredNode()` method is and throws an error because of not being able to find any node.

# Important changes

- changed `getHoveredNode()` method in `graph.component.ts` to return undefined if the simulation has no nodes (the nodes of the simulation are cleared on loading another tracemap).
- small changes to `tweet.component.ts` to catch promise rejections if tweets are deleted before they are rendered completely. (Has been part of #107 which is not reproducable but quick resorting is sometimes throwing errors in `twitter.widgets.js` (twitters embed tweets script))

# Review hints

1. Load random tracemap
2. Load new tracemaps and hover/click the canvas while its loading
3. Watch the web-console, no errors should appear