### PR TITLE
fix datetime key and use iso formatted datetime string

### DIFF
--- a/src/app/tool/services/logging.service.ts
+++ b/src/app/tool/services/logging.service.ts
@@ -12,9 +12,9 @@ export class LoggingService {
     ) {}
 
     startTracemapGeneration(tweetId: string) {
-        const timeString = Math.floor(Date.now() / 1000).toString();
+        const date = new Date()
         this.tracemapLog = {
-            time_str: timeString,
+            datetime: date.toISOString(),
             tweet_id_str: tweetId,
             count: 1
         };


### PR DESCRIPTION
Resolves #143   
Epic: tracemap/tracemap-backend#58

Merge together with tracemap/tracemap-backend#111

# Important changes

- changed logging datetime key from `time_str` to `datetime`
- using `Date.toISOstring` instead of unix timestamp

# Review hints

- [ ] generate a tracemap and check if its logged correctly at the netcup server.